### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/ayan9093/33597088-4ab4-4d1e-ae89-f4593caf068b/362e1ff5-3bf3-4363-9987-3f9c4e561172/_apis/work/boardbadge/5f668d10-7879-4ef6-bc66-c227c7ee187d)](https://dev.azure.com/ayan9093/33597088-4ab4-4d1e-ae89-f4593caf068b/_boards/board/t/362e1ff5-3bf3-4363-9987-3f9c4e561172/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#10](https://dev.azure.com/ayan9093/33597088-4ab4-4d1e-ae89-f4593caf068b/_workitems/edit/10). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.